### PR TITLE
fix: fallback for app block toggled off if theme not found

### DIFF
--- a/app/common.client/procedures/app-embed-status.ts
+++ b/app/common.client/procedures/app-embed-status.ts
@@ -28,9 +28,9 @@ export async function appEmbedStatus(appEmbedUuid: string) {
     return false;
   }
   /**current can be a string for example "DEFAULT" for new theme installations */
-  const { current } = JSON5.parse(settingsData) as { current: {blocks: Record<string, { type: string; disabled?: boolean }>} | string };
+  const { current } = JSON5.parse(settingsData) as { current?: {blocks: Record<string, { type: string; disabled?: boolean }>} | string };
 
-  if (typeof current === 'string' || current instanceof String) {
+  if (typeof current === 'string' || current instanceof String || current === undefined) {
     return false;
   }
 


### PR DESCRIPTION
In some cases we are unable to retrieve the current active theme. add a fallback to set app block status to disabled

fixes #12 