### PR TITLE
feat: support self hosted PostHog instances for ui_host

### DIFF
--- a/app/routes/app.js-web-posthog-settings/route.tsx
+++ b/app/routes/app.js-web-posthog-settings/route.tsx
@@ -94,20 +94,6 @@ export default function JsWebEvents() {
   const jsWebPosthogSettingsInitialState = defaultJsWebPosthogSettings.map<JsWebPosthogSettingChoice>((entry) => {
     return {
       ...entry,
-      ...(entry.key == 'ui_host' && entry.type == SettingType.Select && {
-        selectOptions: entry.selectOptions.map((v) => {
-          const label = (() => {
-            if (v == 'https://eu.posthog.com') {
-              return 'Posthog EU'
-            }
-            return 'Posthog US'
-          })();
-          return {
-            label: label,
-            value: v,
-          }
-        })
-      }),
       value: jsWebPosthogSettingsMetafieldValue?.[entry.key],
     } as JsWebPosthogSettingChoice;
 
@@ -219,7 +205,7 @@ export default function JsWebEvents() {
   };
 
   const dirty = useMemo(() => {
-   
+
     const diff = detailedDiff(jsWebPosthogSettingsInitialState || {}, jsWebPosthogSettings);
 
     if (Object.values(diff).some((changeType: object) => Object.keys(changeType).length != 0)) {

--- a/common/dto/js-web-settings.dto.ts
+++ b/common/dto/js-web-settings.dto.ts
@@ -3,9 +3,10 @@ export const JsWebPosthogConfigSchema = z.object({
   /* api_host: z.string().describe('URL of your PostHog instance.').trim().url().nullish().default(''), */
 
   ui_host: z
-    .enum(['https://us.posthog.com', 'https://eu.posthog.com'])
+    .string()
+    .url()
     .describe(
-      `If using a reverse proxy for 'api_host' then this should be the actual PostHog app URL (e.g. https://us.posthog.com). This ensures that links to PostHog point to the correct host.`
+      `If using a reverse proxy for 'api_host' then this should be the actual PostHog app URL (e.g. https://us.posthog.com, https://eu.posthog.com). This ensures that links to PostHog point to the correct host. If using a self-hosted PostHog instance, provide your custom URL here.`
     )
     .nullable()
     .default("https://us.posthog.com"),
@@ -134,14 +135,14 @@ export const JsWebPosthogConfigSchema = z.object({
 
   // the following will not be implemented
   /**
-   * 
+   *
   sanitize_properties: z.unknown().transform(() => null),
   loaded: z.unknown().transform(() => null),
   bootstrap: z.unknown().transform(() => null),
   session_recording: z.unknown().transform(() => null),
   xhr_headers: z.unknown().transform(() => null),
   autocapture: z.unknown().transform(() => null),
-  
+
   'autocapture.url_allowlist': z
     .array(z.string().trim())
     .describe(


### PR DESCRIPTION
closes #27 

In order to support self hosted PostHog instances I switched the `ui_host` setting from type `enum` to `string`. A downside is that users will have to provide the URL also when PostHog cloud services now. I updated the field description accordingly. The settings were similar (string instead of enum) before they were changed to a select option in 451f9de6. I do not know why that change has been made (probably to make configuration easier) and if it's feasible to return to the old state.

A more complicated solution would be to offer an additional enum option "self hosted" and a text field that is only visible when self hosted is selected.

DISCLAIMER: I did not manage to set up the app in a dev store in short time (at the end I failed with the prisma setup) and though were not able to test my changes.